### PR TITLE
added ability to configure plugins

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@ Its usage should be very similar to `Ember.Select`, but with additional features
 - `selection` - Ember-selectize will set this binding to the selection that was made. Usually some property on a model, for example. If `multiple` is `true`, then it should be an array.
 - `optionValuePath` - Selectize requires a unique hash for each option available. Set this to a path to such a property on your options. Prefix with `content.`. Example: `content.id`
 - `optionLabelPath` - Set this to a path where selectize can get a label for display. Computed properties are many times useful for this. Example: `content.name`
+- `plugins` - Set this to a comma delimited list of selectize plugins to override the default plugin selection (currently remove_button). Note, not all plugins have been tested to work with ember-cli-selectize, YMMV. Example: `restore_on_backspace,drag_drop`
 - `placeholder` or `prompt` - Set any of these to display a text when there is no choice made. Example `"Please select an- option"`
 - `disabled` - If `true` disables changes in selectize
 - `multiple` - If `true` ember-selectize will enter multiple mode. `selection` is an array of options.

--- a/addon/components/ember-selectize.js
+++ b/addon/components/ember-selectize.js
@@ -109,7 +109,7 @@ export default Ember.Component.extend({
 
     //Split the passed in plugin config into an array.
     if (typeof this.plugins === 'string') {
-      this.plugins = this.plugins.split(',');
+      this.plugins = this.plugins === "" ? [] : this.plugins.split(',');
     }
 
     //We proxy callbacks through jQuery's 'proxy' to have the callbacks context set to 'this'

--- a/addon/components/ember-selectize.js
+++ b/addon/components/ember-selectize.js
@@ -109,7 +109,7 @@ export default Ember.Component.extend({
 
     //Split the passed in plugin config into an array.
     if (typeof this.plugins === 'string') {
-      this.plugins = this.plugins === "" ? [] : this.plugins.split(',').map((item) => { return item.trim(); })
+      this.plugins = this.plugins === "" ? [] : this.plugins.split(',').map(item => item.trim() )
     }
 
     //We proxy callbacks through jQuery's 'proxy' to have the callbacks context set to 'this'

--- a/addon/components/ember-selectize.js
+++ b/addon/components/ember-selectize.js
@@ -29,7 +29,7 @@ export default Ember.Component.extend({
   /**
   * The array of the default plugins to load into selectize
   */
-  plugins: ['remove_button'],
+  plugins: [],
 
   /**
   * Computed properties that hold the processed paths ('content.' replacement),
@@ -106,6 +106,11 @@ export default Ember.Component.extend({
 
   selectizeOptions: Ember.computed(function() {
     var allowCreate = get(this, 'create');
+
+    //Split the passed in plugin config into an array.
+    if (typeof this.plugins === 'string') {
+      this.plugins = this.plugins.split(',');
+    }
 
     //We proxy callbacks through jQuery's 'proxy' to have the callbacks context set to 'this'
     return {

--- a/addon/components/ember-selectize.js
+++ b/addon/components/ember-selectize.js
@@ -109,7 +109,7 @@ export default Ember.Component.extend({
 
     //Split the passed in plugin config into an array.
     if (typeof this.plugins === 'string') {
-      this.plugins = this.plugins === "" ? [] : this.plugins.split(',');
+      this.plugins = this.plugins === "" ? [] : this.plugins.split(',').map((item) => { return item.trim(); })
     }
 
     //We proxy callbacks through jQuery's 'proxy' to have the callbacks context set to 'this'

--- a/addon/components/ember-selectize.js
+++ b/addon/components/ember-selectize.js
@@ -29,7 +29,7 @@ export default Ember.Component.extend({
   /**
   * The array of the default plugins to load into selectize
   */
-  plugins: [],
+  plugins: ['remove_button'],
 
   /**
   * Computed properties that hold the processed paths ('content.' replacement),


### PR DESCRIPTION
It is useful to be able to define plugins on a case by case basis, this commit allows you to do so by passing in a comma delimited string defining the selectize.js plugins you want to apply.

pass plugin='remove_button,other_plugin' to choose plugins

Signed-off-by: Laura Busl <laura.busl@outlook.com>