### PR TITLE
Fix render functions context

### DIFF
--- a/addon/components/ember-selectize.js
+++ b/addon/components/ember-selectize.js
@@ -90,7 +90,7 @@ export default Ember.Component.extend({
       var renderFunction = get(this,functionPropertyName);
       // functions take precedence
       if(renderFunction){
-        renderFunctions[item] = renderFunction.bind(this);
+        renderFunctions[item] = renderFunction.bind(this.get('targetObject'));
       } else {
         // infer the view name by camelizing selectize's function and appending a view suffix (overridable)
         var templateSuffix = get(this,'templateSuffix'),


### PR DESCRIPTION
Currently `this` in render functions refers to the component not the parent context. 