### PR TITLE
Allow for false theme option

### DIFF
--- a/index.js
+++ b/index.js
@@ -8,7 +8,9 @@ module.exports = {
     var options = app.options['ember-cli-selectize'] || { theme: 'default' };
 
     //import theme based on options
-    app.import(app.bowerDirectory + '/selectize/dist/css/selectize.' + options.theme + '.css');
+    if (options.theme){
+      app.import(app.bowerDirectory + '/selectize/dist/css/selectize.' + options.theme + '.css');
+    }
 
     //import javascript
     app.import(app.bowerDirectory + '/selectize/dist/js/standalone/selectize.js');


### PR DESCRIPTION
It appears that setting false in the theme property (Brocfile) is not accounted for in the setup of this component.  The end-result is an error since it cannot find the file ```selectize.false.css```

This wraps the import in a simple conditional.