### PR TITLE
Respect optionValuePath when multiple

### DIFF
--- a/addon/components/ember-selectize.js
+++ b/addon/components/ember-selectize.js
@@ -29,10 +29,15 @@ export default Ember.Component.extend({
   optionLabelPath: 'content',
 
   selection: null,
-  value: computed('selection', {get: function() {
-    var valuePath = this.get('_valuePath');
-    return valuePath ? this.get('selection.' + valuePath) : this.get('selection');
-  }, set: function(key, value){ return value; }}),
+  value: computed('selection', {
+    get: function() {
+      var valuePath = this.get('_valuePath');
+      return valuePath ? this.get('selection.' + valuePath) : this.get('selection');
+    },
+    set: function(key, value){
+      return value;
+    }
+  }),
 
   /**
   * The array of the default plugins to load into selectize
@@ -263,14 +268,20 @@ export default Ember.Component.extend({
     });
   },
   _addSelection: function(obj) {
-    this.get('selection').addObject(obj);
+    var valuePath = this.get('_valuePath');
+    var item = valuePath ? get(obj, valuePath) : obj;
+
+    this.get('selection').addObject(item);
 
     Ember.run.schedule('actions', this, function() {
-      this.sendAction('add-item', obj);
+      this.sendAction('add-item', item);
     });
   },
   _removeSelection: function(obj) {
-    this.get('selection').removeObject(obj);
+    var valuePath = this.get('_valuePath');
+    var item = valuePath ? get(obj, valuePath) : obj;
+
+    this.get('selection').addObject(item);
 
     Ember.run.schedule('actions', this, function() {
       this.sendAction('remove-item', obj);
@@ -381,7 +392,7 @@ export default Ember.Component.extend({
   */
   selectionObjectWasAdded: function(obj) {
     if (this._selectize) {
-      this._selectize.addItem(get(obj, this.get('_valuePath')));
+      this._selectize.addItem(obj);
     }
   },
   /*
@@ -389,7 +400,7 @@ export default Ember.Component.extend({
   */
   selectionObjectWasRemoved: function(obj) {
     if (this._selectize) {
-      this._selectize.removeItem(get(obj, this.get('_valuePath')));
+      this._selectize.removeItem(obj);
     }
   },
   /**

--- a/tests/unit/components/ember-selectize-test.js
+++ b/tests/unit/components/ember-selectize-test.js
@@ -290,6 +290,52 @@ test('adding a multiple selection updates selectize selection', function(assert)
   assert.deepEqual(component._selectize.items, ['item 2', 'item 3', 'item 4']);
 });
 
+test('adding a multiple selection updates component selection from optionValuePath', function(assert) {
+  var component = this.subject();
+  var item1 = { label: 'label 1', value: 'value 1' };
+  var item2 = { label: 'label 2', value: 'value 2' };
+  var item3 = { label: 'label 3', value: 'value 3' };
+  var item4 = { label: 'label 4', value: 'value 4' };
+
+  Ember.run(function() {
+    component.set('content', [item1, item2, item3, item4]);
+    component.set('selection', [item2.value, item3.value]);
+    component.set('multiple', true);
+    component.set('optionValuePath', 'content.value');
+    component.set('optionLabelPath', 'content.label');
+  });
+  this.render();
+  assert.deepEqual(component.get('selection').length, 2);
+  assert.deepEqual(component.get('selection'), [item2.value, item3.value]);
+  Ember.run(function() {
+    component.get('selection').pushObject(item4.value);
+  });
+  assert.deepEqual(component.get('selection').length, 3);
+  assert.deepEqual(component.get('selection'), [item2.value, item3.value, item4.value]);
+});
+
+test('removing a multiple selection updates component selection from optionValuePath', function(assert) {
+  var component = this.subject();
+  var item1 = { label: 'label 1', value: 'value 1' };
+  var item2 = { label: 'label 2', value: 'value 2' };
+
+  Ember.run(function() {
+    component.set('content', [item1, item2]);
+    component.set('selection', [item1.value, item2.value]);
+    component.set('multiple', true);
+    component.set('optionValuePath', 'content.value');
+    component.set('optionLabelPath', 'content.label');
+  });
+  this.render();
+  assert.deepEqual(component.get('selection').length, 2);
+  assert.deepEqual(component.get('selection'), [item1.value, item2.value]);
+  Ember.run(function() {
+    component.get('selection').removeObject(item2.value);
+  });
+  assert.deepEqual(component.get('selection').length, 1);
+  assert.deepEqual(component.get('selection'), [item1.value]);
+});
+
 test('it sends update-filter action when changing filter', function(assert) {
   assert.expect(1);
 


### PR DESCRIPTION
This adds support for `optionValuePath` when `multiple: true`.

### Use Case

I often want to have a select that is populated with Ember Data objects but only care about selecting one of their values, such as their `id`. This is especially useful when using a select as a way of populating query params.

For example, imagine you have a search controller:

```javascript
export default Ember.Controller.extend({
  queryParams: ['tagIds'],
  
  tags: [],
  tagIds: []
});
```

The value for `tags` comes from a collection of Ember Data objects set in the route:

```javascript
export default Ember.Route.extend({
  setupController: function(controller, model) {
    this._super(controller, model);

    var tags = this.store.find('tag');
    set(controller, 'tags', tags);
  }
});
```

Your API might expect to receive an array of tag ids in the query params. To support this, you'd want to add something like the following to the search template:

```handlebars
{{ember-selectize selection=tagIds
  content=tags
  optionLabelPath="content.name"
  optionValuePath="content.id"}}
```

### TL;DR;

It's confusing that setting the `optionValuePath` is not respected by ember-selectize. If you want to select the entire object rather than one of it's properties, you can simply not specify an `optionValuePath` or specify `content` as it's value.