### PR TITLE
skipping any erroneous items from selectionArrayWillChange

### DIFF
--- a/addon/components/ember-selectize.js
+++ b/addon/components/ember-selectize.js
@@ -363,11 +363,7 @@ export default Ember.Component.extend({
   selectionArrayWillChange: function(array, idx, removedCount) {
     this._removing = true;
     for (var i = idx; i < idx + removedCount; i++) {
-      var obj = array.objectAt(i);
-      if (obj.isError) {
-        continue;
-      }
-      this.selectionObjectWasRemoved(obj);
+      this.selectionObjectWasRemoved(array.objectAt(i));
     }
     this._removing = false;
   },
@@ -442,7 +438,11 @@ export default Ember.Component.extend({
   */
   contentArrayWillChange: function(array, idx, removedCount) {
     for (var i = idx; i < idx + removedCount; i++) {
-      this.objectWasRemoved(array.objectAt(i));
+      var obj = array.objectAt(i);
+      if (obj.isError) {
+        continue;
+      }
+      this.objectWasRemoved(obj);
     }
 
     if (this._selectize) {

--- a/addon/components/ember-selectize.js
+++ b/addon/components/ember-selectize.js
@@ -363,7 +363,11 @@ export default Ember.Component.extend({
   selectionArrayWillChange: function(array, idx, removedCount) {
     this._removing = true;
     for (var i = idx; i < idx + removedCount; i++) {
-      this.selectionObjectWasRemoved(array.objectAt(i));
+      var obj = array.objectAt(i);
+      if (obj.isError) {
+        continue;
+      }
+      this.selectionObjectWasRemoved(obj);
     }
     this._removing = false;
   },


### PR DESCRIPTION
When creating a new record, and persisting the record, server side validation can force the record into an erroneous state.  When this comes back, the obj can be an empty "isError" record, which causes _selectize.removeItem to choke.