### PR TITLE
Data down actions up.

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -12,5 +12,8 @@
     "loader.js": "ember-cli/loader.js#3.2.0",
     "qunit": "~1.17.1",
     "selectize": "~0.12.0"
+  },
+  "resolutions": {
+    "ember": "1.11.1"
   }
 }

--- a/index.js
+++ b/index.js
@@ -14,5 +14,8 @@ module.exports = {
 
     //import javascript
     app.import(app.bowerDirectory + '/selectize/dist/js/standalone/selectize.js');
+  },
+  isDevelopingAddon: function() {
+    return true;
   }
 };

--- a/tests/unit/components/ember-selectize-test.js
+++ b/tests/unit/components/ember-selectize-test.js
@@ -217,29 +217,6 @@ test('replacing content updates selectize options', function(assert) {
   assert.deepEqual(asArray(component._selectize.options, 'label'), ['item 1']);
 });
 
-
-test('setting value does update selectize items', function(assert) {
-  var component = this.subject();
-  Ember.run(function() {
-    component.set('content', ['item 1', 'item 2', 'item 3']);
-    component.set('value', 'item 2');
-  });
-  this.render();
-  assert.equal(component._selectize.items.length, 1);
-  assert.deepEqual(component._selectize.items, ['item 2']);
-});
-
-test('setting value does not update selection property', function(assert) {
-  var component = this.subject();
-  Ember.run(function() {
-    component.set('content', ['item 1', 'item 2', 'item 3']);
-    component.set('value', 'item 2');
-  });
-  this.render();
-  assert.equal(component.get('selection'), null);
-});
-
-
 test('having a selection creates selectize with a selection', function(assert) {
   var component = this.subject();
   Ember.run(function() {

--- a/tests/unit/components/ember-selectize-test.js
+++ b/tests/unit/components/ember-selectize-test.js
@@ -217,6 +217,29 @@ test('replacing content updates selectize options', function(assert) {
   assert.deepEqual(asArray(component._selectize.options, 'label'), ['item 1']);
 });
 
+
+test('setting value does update selectize items', function(assert) {
+  var component = this.subject();
+  Ember.run(function() {
+    component.set('content', ['item 1', 'item 2', 'item 3']);
+    component.set('value', 'item 2');
+  });
+  this.render();
+  assert.equal(component._selectize.items.length, 1);
+  assert.deepEqual(component._selectize.items, ['item 2']);
+});
+
+test('setting value does not update selection property', function(assert) {
+  var component = this.subject();
+  Ember.run(function() {
+    component.set('content', ['item 1', 'item 2', 'item 3']);
+    component.set('value', 'item 2');
+  });
+  this.render();
+  assert.equal(component.get('selection'), null);
+});
+
+
 test('having a selection creates selectize with a selection', function(assert) {
   var component = this.subject();
   Ember.run(function() {


### PR DESCRIPTION
This pr changes the functionality of this addon significantly.  It removes the `value` attribute and changes `selected` to read only.  

At first I attempted to allow both "two way binding" or "oneway with actions" but failed to come up with a elegant way to differentiate between the two.  

Personally I have come to the conclusion that the component should not mutate the object but only send actions and if I want the component to mutate a property I should wrap the component in another component and implement the mutation there. 


