### PR TITLE
fix value property.

### DIFF
--- a/addon/components/ember-selectize.js
+++ b/addon/components/ember-selectize.js
@@ -28,7 +28,8 @@ export default Ember.Component.extend({
   optionLabelPath: 'content',
 
   selection: null,
-  value: computed('selection', function() {
+  value: computed('selection', function(key, value) {
+    if (arguments.length === 2) { return value; }
     var valuePath = this.get('_valuePath');
     return valuePath ? this.get('selection.' + valuePath) : this.get('selection');
   }),

--- a/tests/unit/components/ember-selectize-test.js
+++ b/tests/unit/components/ember-selectize-test.js
@@ -260,6 +260,25 @@ test('updating a selection updates selectize selection', function(assert) {
   assert.deepEqual(component._selectize.items, ['item 3']);
 });
 
+test('updating a selection updates selectize value', function(assert) {
+  var component = this.subject();
+  var content = exampleObjectContent();
+  Ember.run(function() {
+    component.set('content', content);
+    component.set('optionValuePath', 'content.id');
+    component.set('optionLabelPath', 'content.label');
+    component.set('value', 1);
+  });
+  this.render();
+  assert.equal(component._selectize.getValue(), 1);
+  assert.equal(component.get('selection'), content.objectAt(0));
+  Ember.run(function() {
+    component._selectize.setValue(2);
+  });
+  assert.equal(component.get('value'), 2);
+  assert.equal(component.get('selection'), content.objectAt(1));
+});
+
 test('replacing a multiple selection updates selectize selection', function(assert) {
   var component = this.subject();
   Ember.run(function() {


### PR DESCRIPTION
Adds back setting value since it was taken out in the
new computed syntax change. Was breaking some of our
selects

I couldn't figure out how to write a failing test for this, would love some ideas to add to this PR.