### PR TITLE
Added demoURL for emberaddons.com

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
     "combobox"
   ],
   "ember-addon": {
-    "configPath": "tests/dummy/config"
+    "configPath": "tests/dummy/config",
+    "demoURL": "http://miguelcobain.github.io/ember-selectize"
   }
 }


### PR DESCRIPTION
Allows Ember Addons to show a demo link for the project