### PR TITLE
Replaced `beforeObserver` with `addObserver`

### DIFF
--- a/addon/components/ember-selectize.js
+++ b/addon/components/ember-selectize.js
@@ -158,6 +158,12 @@ export default Ember.Component.extend({
 
     return options;
   }),
+  
+  _setupSelectionObservers: function() {
+        //Setting up observers for changes to selection and content bindings (after the array observers are initialized).
+        Ember.addObserver(this, 'selection', '_selectionWillChange');
+        Ember.addObserver(this, 'content', '_contentWillChange');
+    }.on('init'),
 
   didInsertElement: function() {
     // ensure selectize is loaded
@@ -180,11 +186,6 @@ export default Ember.Component.extend({
     if (!isNone(value)) { this._valueDidChange(); }
 
     this._loadingDidChange();
-    
-    //Setting up observers for changes to selection and content bindings (after the array observers are initialized).
-    Ember.addObserver(this, 'selection', '_selectionWillChange');
-    Ember.addObserver(this, 'content', '_contentWillChange');
-    
   },
 
   willDestroyElement: function() {


### PR DESCRIPTION
Replaces the deprecated `beforeObserver` with `addObserver`.

`_selectionWillChange()` and `_contentWillChange()` now operate by passing in `this` when the keys update.

This in theory, passes in the state of the component just before the value changes... however in practice this is not fully tested.

It does, however solve the deprecation, and (so far) has not triggered any errors for me.