### PR TITLE
adding clear selection plugin

### DIFF
--- a/addon/components/ember-selectize.js
+++ b/addon/components/ember-selectize.js
@@ -199,8 +199,15 @@ export default Ember.Component.extend({
       this.plugins = this.plugins === '' ? [] : this.plugins.split(', ').map(item => item.trim());
     }
 
+    //Rebuild into object for plugin option support
+    var plugins = {};
+    this.plugins.forEach(plugin => plugins[plugin] = {});
+    if (plugins['clear_selection'] && this.get('clear-selection')) {
+      plugins['clear_selection'].title = this.get('clear-selection');
+    }
+
     var options = {
-      plugins: this.plugins,
+      plugins: plugins,
       labelField: 'label',
       valueField: 'value',
       searchField: 'label',
@@ -214,7 +221,7 @@ export default Ember.Component.extend({
       onBlur: this._registerAction('on-blur'),
       onFocus: this._registerAction('on-focus'),
       onInitialize: this._registerAction('on-init'),
-      onClear: this._registerAction('on-clear')
+      onClear: Ember.run.bind(this, '_onClear')
     };
 
     var generalOptions = ['delimiter', 'diacritics', 'createOnBlur',
@@ -308,6 +315,17 @@ export default Ember.Component.extend({
     this.set('filter', str);
     Ember.run.schedule('actions', this, function() {
       this.sendAction('update-filter', str);
+    });
+  },
+
+  /**
+  * Event callback that is triggered when user clears selection
+  */
+  _onClear() {
+    this.set('selection', null);
+
+    Ember.run.schedule('actions', this, function() {
+      this.sendAction('clear');
     });
   },
 

--- a/addon/initializers/selectize-clear-selection.js
+++ b/addon/initializers/selectize-clear-selection.js
@@ -1,0 +1,33 @@
+/**
+ * Based on https://gist.github.com/jumika/abe412f1aa2b24ea86e6
+ */
+import Ember from 'ember';
+
+export default function() {
+  /* globals Selectize */
+  Selectize.define('clear_selection', function(options) {
+    var self = this;
+    var settings = Ember.$.extend({
+      title: 'Clear selection'
+    }, options);
+
+    //Overriding because, ideally you wouldn't use header & clear_selection simultaneously
+    self.plugins.settings.dropdown_header = {
+      title: settings.title
+    };
+    this.require('dropdown_header');
+
+    self.setup = (() => {
+      var original = self.setup;
+      return () => {
+        original.apply(this, arguments);
+        this.$dropdown.find('.selectize-dropdown-header').addClass('clear-selection').on('mousedown', () => {
+          self.clear();
+          self.close();
+          self.blur();
+          return false;
+        });
+      };
+    })();
+  });
+}

--- a/app/initializers/selectize-clear-selection.js
+++ b/app/initializers/selectize-clear-selection.js
@@ -1,0 +1,6 @@
+import initialize from 'ember-cli-selectize/initializers/selectize-clear-selection';
+
+export default {
+  name: 'selectize-clear-selection',
+  initialize: initialize
+};


### PR DESCRIPTION
This pullrequest adds plugin into Selection library, that add option to deselect selectbox. 

To activate it you have to add ```plugins=clear_selection```, and optionally override default text ```clear_selection="Deselect"```

What do you think? @miguelcobain 
If desired I could also add another plugin. Which instead of option adds X next to the selected item.

fixes #43