### PR TITLE
Catches exception thrown by Ember 2.0 when no item is selected #91

### DIFF
--- a/addon/components/ember-selectize.js
+++ b/addon/components/ember-selectize.js
@@ -437,15 +437,18 @@ export default Ember.Component.extend({
       } else {
         if (selection.then) {
           selection.then(function (resolved) {
+
+            var selectedItem = self._getWithExceptionHandling(resolved, self.get('_valuePath'));
+
             // Ensure that we don't overwrite new value
             if (get(self, 'selection') === selection) {
-              self._selectize.addItem(get(resolved, self.get('_valuePath')));
+              self._selectize.addItem(selectedItem);
             }
+
           });
         } else {
           this._selectize.addItem(get(selection, this.get('_valuePath')));
         }
-
       }
 
     } else {
@@ -454,6 +457,17 @@ export default Ember.Component.extend({
       this._selectize.showInput();
     }
   }),
+
+  // Fix: Restore error handling before Ember 2.0
+  _getWithExceptionHandling: function(obj, keyName) {
+    var propertyValue;
+    try {
+      propertyValue = get(obj, keyName);
+    } catch(e) {
+      propertyValue = undefined;
+    }
+    return propertyValue;
+  },
 
   /**
    * It is possible to control the selected item through its value.


### PR DESCRIPTION
Ember 2.0 changed the behavior of Ember.get(obj, keyName). If obj is undefined or null, older versions of Ember return undefined. With the changes of Ember 2.0 this behavior changed and an exception is been thrown. This exception can be reproduced when no item is selected (selection = null).
 The changes restore the old behavior of Ember.get by wrapping it in the method _getWithExceptionHandling. 