### PR TITLE
use ember-new-computed only when needed (fixes #98)

### DIFF
--- a/addon/components/ember-selectize.js
+++ b/addon/components/ember-selectize.js
@@ -1,7 +1,14 @@
 import Ember from 'ember';
-import computed from 'ember-new-computed';
-var get = Ember.get, isArray = Ember.isArray, typeOf = Ember.typeOf,
-  isNone = Ember.isNone, camelize = Ember.String.camelize;
+import computedPolyfill from 'ember-new-computed';
+
+const {
+  computed,
+  get,
+  isArray,
+  isNone,
+  typeOf
+} = Ember;
+const { camelize } = Ember.String;
 
 /**
  * Ember.Selectize is an Ember View that encapsulates a Selectize component.
@@ -31,7 +38,7 @@ export default Ember.Component.extend({
   optionGroupPath: 'content.group',
 
   selection: null,
-  value: computed('selection', {
+  value: computedPolyfill('selection', {
     get() {
       var valuePath = this.get('_valuePath');
       var selection = this.get('selection');


### PR DESCRIPTION
`ember-new-computed` can cause problems with methods like `alias`(see #98). To avoid this, this PR restricts the use of `ember-new-computed` to `get` & `set`. Once support for Ember <1.12 is dropped, we can replace `computedPolyfill` with `computed`.