### PR TITLE
DEPRECATION: A property of <project@view:-outlet::ember579> was modified inside the didInsertElement hook.

### DIFF
--- a/addon/components/ember-selectize.js
+++ b/addon/components/ember-selectize.js
@@ -478,7 +478,9 @@ export default Ember.Component.extend({
         return value === (valuePath ? get(obj, valuePath) : obj);
       }) : null;
 
-      this.set('selection', selection);
+      Ember.run.next(() => {
+        this.set('selection', selection);
+      });
     }
   }),
 

--- a/tests/unit/components/ember-selectize-test.js
+++ b/tests/unit/components/ember-selectize-test.js
@@ -510,20 +510,27 @@ test('updating a selection updates selectize selection', function(assert) {
 test('updating a selection updates selectize value', function(assert) {
   var component = this.subject();
   var content = exampleObjectContent();
+
   Ember.run(function() {
     component.set('content', content);
     component.set('optionValuePath', 'content.id');
     component.set('optionLabelPath', 'content.label');
     component.set('value', 1);
   });
+
   this.render();
-  assert.equal(component._selectize.getValue(), 1);
-  assert.equal(component.get('selection'), content.objectAt(0));
+
+  Ember.run.next(function() {
+    assert.equal(component._selectize.getValue(), 1);
+    assert.equal(component.get('selection'), content.objectAt(0));
+  });
+
   Ember.run(function() {
     component._selectize.setValue(2);
+
+    assert.equal(component.get('value'), 2);
+    assert.equal(component.get('selection'), content.objectAt(1));
   });
-  assert.equal(component.get('value'), 2);
-  assert.equal(component.get('selection'), content.objectAt(1));
 });
 
 test('replacing a multiple selection updates selectize selection', function(assert) {


### PR DESCRIPTION
Fix for this specific deprecation:

DEPRECATION: A property of <project@view:-outlet::ember579> was modified inside the didInsertElement hook. You should never change properties on components, services or models during didInsertElement because it causes significant performance degradation.