### PR TITLE
Upgrading loading to 3.3.0 to fix warning

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -9,7 +9,7 @@
     "ember-qunit-notifications": "0.0.7",
     "ember-resolver": "~0.1.18",
     "jquery": "^1.11.1",
-    "loader.js": "ember-cli/loader.js#3.2.0",
+    "loader.js": "ember-cli/loader.js#3.3.0",
     "qunit": "~1.17.1",
     "selectize": "~0.12.0"
   }


### PR DESCRIPTION
`unable to require.unsee, please upgrade loader.js to >= v3.3.0`
resolve https://github.com/miguelcobain/ember-cli-selectize/issues/127