### PR TITLE
Replace didInsertElement to deal with deprecation

### DIFF
--- a/addon/components/ember-selectize.js
+++ b/addon/components/ember-selectize.js
@@ -226,6 +226,35 @@ export default Ember.Component.extend({
     return options;
   }),
 
+  onInit: function() {
+    Ember.run.schedule('afterRender', this, function () {
+      // ensure selectize is loaded
+      Ember.assert('selectize has to be loaded', typeof this.$().selectize === 'function');
+
+      //Create Selectize's instance
+      this.$().selectize(this.get('selectizeOptions'));
+
+      //Save the created selectize instance
+      this._selectize = this.$()[0].selectize;
+
+      //Some changes to content, selection and disabled could have happened before the Component was inserted into the DOM.
+      //We trigger all the observers manually to account for those changes.
+      this._disabledDidChange();
+      this._optgroupsDidChange();
+      if(this.get('groupedContent')) {
+        this._groupedContentDidChange();
+      }
+      this._contentDidChange();
+
+      var selection = this.get('selection');
+      var value = this.get('value');
+      if (!isNone(selection)) { this._selectionDidChange(); }
+      if (!isNone(value)) { this._valueDidChange(); }
+
+      this._loadingDidChange();
+    });
+  }.on('init'),
+
   didInsertElement() {
     // ensure selectize is loaded
     Ember.assert('selectize has to be loaded', typeof this.$().selectize === 'function');


### PR DESCRIPTION
Used `Ember.run.schedule('afterRender'...` on init to deal with the deprecation:

DEPRECATION: A property of was modified inside the didInsertElement hook. You should never change properties on components, services or models during didInsertElement because it causes significant performance degradation.