### PR TITLE
Couldn't find module `ember-getowner-polyfill` 

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,6 @@
     "ember-disable-prototype-extensions": "^1.1.0",
     "ember-disable-proxy-controllers": "^1.0.1",
     "ember-export-application-global": "^1.0.5",
-    "ember-getowner-polyfill": "1.0.1",
     "ember-load-initializers": "^0.5.1",
     "ember-resolver": "^2.0.3",
     "ember-try": "^0.2.2",
@@ -46,6 +45,7 @@
   },
   "dependencies": {
     "ember-cli-babel": "^5.1.5",
+    "ember-getowner-polyfill": "1.0.1",
     "ember-new-computed": "^1.0.0"
   },
   "keywords": [


### PR DESCRIPTION
In Ember v2.5.0, was getting this error:
`Uncaught Error: Could not find module ember-getowner-polyfill imported from ember-cli-selectize/components/ember-selectize`

This module was as a devDependency, changed to dependency for production