### PR TITLE
Update included hook for nested addons

### DIFF
--- a/index.js
+++ b/index.js
@@ -4,17 +4,24 @@
 module.exports = {
   name: 'ember-cli-selectize',
   included: function(app) {
+    this._super.included.apply(this, arguments);
+
+    var host = this._findHost();
+
     //default theme name is 'default'
-    var options = app.options['ember-cli-selectize'] || { theme: 'default' };
+    var options = { theme: 'default' };
+    if (host.options && host.options['ember-cli-selectize']) {
+      options = host.options['ember-cli-selectize'];
+    }
 
     if (process.env.EMBER_CLI_FASTBOOT !== 'true') {
       //import theme based on options
-      if (options.theme){
-        app.import(app.bowerDirectory + '/selectize/dist/css/selectize.' + options.theme + '.css');
+      if (options.theme) {
+        this.import(host.bowerDirectory + '/selectize/dist/css/selectize.' + options.theme + '.css');
       }
 
       //import javascript
-      app.import(app.bowerDirectory + '/selectize/dist/js/standalone/selectize.js');
+      this.import(host.bowerDirectory + '/selectize/dist/js/standalone/selectize.js');
     }
   }
 };

--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
   },
   "dependencies": {
     "ember-cli-babel": "^5.1.5",
+    "ember-cli-import-polyfill": "^0.2.0",
     "ember-getowner-polyfill": "1.0.1",
     "ember-new-computed": "^1.0.0"
   },


### PR DESCRIPTION
I update the to add the feature to be nested into another addon. I add `ember-cli-import-polyfill` to have access to the new `this.import` syntax and the polyfill add a nice function  `_findHost` to retrieve informations of the top parent app.
