### PR TITLE
Remove ember-cli-import-polyfill

### DIFF
--- a/index.js
+++ b/index.js
@@ -9,22 +9,20 @@ module.exports = {
       app = app.app;
     }
 
-    var host = this._findHost();
-
     //default theme name is 'default'
     var options = { theme: 'default' };
-    if (host.options && host.options['ember-cli-selectize']) {
-      options = host.options['ember-cli-selectize'];
+    if (app.options && app.options['ember-cli-selectize']) {
+      options = app.options['ember-cli-selectize'];
     }
 
     if (process.env.EMBER_CLI_FASTBOOT !== 'true') {
       //import theme based on options
       if (options.theme) {
-        this.import(host.bowerDirectory + '/selectize/dist/css/selectize.' + options.theme + '.css');
+        app.import(app.bowerDirectory + '/selectize/dist/css/selectize.' + options.theme + '.css');
       }
 
       //import javascript
-      this.import(host.bowerDirectory + '/selectize/dist/js/standalone/selectize.js');
+      app.import(app.bowerDirectory + '/selectize/dist/js/standalone/selectize.js');
     }
   }
 };

--- a/index.js
+++ b/index.js
@@ -4,7 +4,10 @@
 module.exports = {
   name: 'ember-cli-selectize',
   included: function(app) {
-    this._super.included.apply(this, arguments);
+    // workaround for https://github.com/ember-cli/ember-cli/issues/3718
+    if (typeof app.import !== 'function' && app.app) {
+      app = app.app;
+    }
 
     var host = this._findHost();
 

--- a/package.json
+++ b/package.json
@@ -43,7 +43,6 @@
   },
   "dependencies": {
     "ember-cli-babel": "^5.1.6",
-    "ember-cli-import-polyfill": "^0.2.0",
     "ember-getowner-polyfill": "1.0.1",
     "ember-new-computed": "^1.0.0"
   },


### PR DESCRIPTION
Hi!
I've encountered an issue in our `add-on` (which uses `ember-cli-selectize`) caused by `ember-cli-import-polyfill` - our bootstrap imports in `scss` add-on files does not work any more. I get the following error: `Error: File to import not found or unreadable: bootstrap`.

This PR removes `ember-cli-import-polyfill` and modifies `included` hook similarly as in the `ember-bootstrap` project. After those changes everything is working fine in our add-on.
