### PR TITLE
Upgrade ember-getowner-polyfill

### DIFF
--- a/addon/components/ember-selectize.js
+++ b/addon/components/ember-selectize.js
@@ -1,6 +1,5 @@
 import Ember from 'ember';
 import computedPolyfill from 'ember-new-computed';
-import getOwner from 'ember-getowner-polyfill';
 
 const {
   Component,
@@ -13,7 +12,8 @@ const {
   isNone,
   typeOf,
   String: { camelize },
-  assert
+  assert,
+  getOwner
 } = Ember;
 const assign = Ember.assign || Ember.merge;
 

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
   "dependencies": {
     "ember-cli-babel": "^5.1.6",
     "ember-cli-import-polyfill": "^0.2.0",
-    "ember-getowner-polyfill": "1.0.1",
+    "ember-getowner-polyfill": "^1.1.1",
     "ember-new-computed": "^1.0.0"
   },
   "keywords": [


### PR DESCRIPTION
The ember-getowner-polyfill addon recently [refactored to be a true polyfill](https://github.com/rwjblue/ember-getowner-polyfill/commit/b46db82dd445b5cd4c596abd020df9d7c500c85a), and it now emits a deprecation if you use it the old way. Even though this addon is currently pinned to 1.0.1, our app is ultimately getting a newer version via another addon, and the deprecation is getting annoying 😁 