### PR TITLE
Fixes add-item-misfire issue by changing the onItemAdd event to onChange.

### DIFF
--- a/addon/components/ember-selectize.js
+++ b/addon/components/ember-selectize.js
@@ -219,7 +219,7 @@ export default Component.extend({
       searchField: 'label',
       optgroupField: 'optgroup',
       create: allowCreate ? run.bind(this, '_create') : false,
-      onItemAdd: run.bind(this, '_onItemAdd'),
+      onChange: run.bind(this, '_onItemAdd'),
       onItemRemove: run.bind(this, '_onItemRemove'),
       onType: run.bind(this, '_onType'),
       render: this.get('renderOptions'),
@@ -463,7 +463,7 @@ export default Component.extend({
             if (resolved) {
               // Ensure that we don't overwrite new value
               if (get(this, 'selection') === selection) {
-                this._selectize.addItem(this.getValueFor(resolved));
+                this._selectize.addItem(this.getValueFor(resolved), true);
               }
             } else {
               //selection was changed to a falsy value. Clear selectize.
@@ -472,7 +472,7 @@ export default Component.extend({
             }
           });
         } else {
-          this._selectize.addItem(this.getValueFor(selection));
+          this._selectize.addItem(this.getValueFor(selection), true);
         }
 
       }
@@ -530,7 +530,7 @@ export default Component.extend({
   */
   selectionObjectWasAdded(obj) {
     if (this._selectize) {
-      this._selectize.addItem(this.getValueFor(obj));
+      this._selectize.addItem(this.getValueFor(obj), true);
     }
   },
 

--- a/tests/unit/components/ember-selectize-test.js
+++ b/tests/unit/components/ember-selectize-test.js
@@ -660,6 +660,35 @@ test('it sends select-item action when an item is selected', function(assert) {
   });
 });
 
+test('it does not send select-item action when selection promise resolves', function(assert) {
+  assert.expect(1);
+
+  var component = this.subject();
+  var selectItem = null;
+
+  var targetObject = {
+    externalAction: function(item) {
+      selectItem = item;
+    }
+  };
+
+  var selection = Ember.RSVP.Promise.resolve("item 1");
+
+  Ember.run(function() {
+    component.set('content', Ember.A(['item 1', 'item 2', 'item 3', 'item 4']));
+    component.set('select-item', 'externalAction');
+    component.set('targetObject', targetObject);
+    component.set('selection', selection);
+  });
+
+  this.render();
+
+  selection.then(function() {
+    assert.equal(selectItem, null, 'externalAction was not called.');
+  });
+
+});
+
 test('it sends select-value action when an item is selected', function(assert) {
   assert.expect(1);
 


### PR DESCRIPTION
Fix for issue #184 

selectize's `add_item` method will always fire the `onItemAdd` event where as the `onChange` event may be silenced.  In this case where we are setting the selection it is important to silence the event.